### PR TITLE
Use u128 instead of bigint and rayon instead of threadpool in Rust impl

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,6 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num-bigint-dig = "0.5.0"
-num-traits = "0.2.8"
-threadpool = "1.7"
+rayon = "1.2"

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,228 +1,58 @@
-// #![feature(test)]
-extern crate num_bigint_dig as num_bigint;
-extern crate num_traits;
-// extern crate test;
-
-use std::time::{SystemTime, UNIX_EPOCH};
-use num_bigint::BigUint;
-use num_traits::{Zero, One};
+use rayon::prelude::*;
 use std::mem::replace;
-// use test::Bencher;
-use std::thread;
-use std::sync::mpsc;
-use threadpool::ThreadPool;
+use std::time::Instant;
 
-fn fib(n: usize) -> BigUint {
-    let mut f0: BigUint = Zero::zero();
-    let mut f1: BigUint = One::one();
+#[inline(never)]
+fn fib(n: usize) -> u128 {
+    let mut f0 = 0u128;
+    let mut f1 = 1u128;
     for _ in 0..n {
-        let f2 = f0 + &f1;
+        let f2 = f0 + f1;
         f0 = replace(&mut f1, f2);
     }
     f0
 }
 
-fn main_pure_threads() {
-    let start = SystemTime::now();
-    fib_thread(2000);
-    let end = SystemTime::now();
-    let duration = end.duration_since(start)
-        .expect("Time went backwards");
-    let ns = duration.as_nanos();
-    println!("fib_2k    {} ns/op", ns/2000);
-    // 3k threads
-    let start = SystemTime::now();
-    fib_thread(3000);
-    let end = SystemTime::now();
-    let duration = end.duration_since(start)
-        .expect("Time went backwards");
-    let ns = duration.as_nanos();
-    println!("fib_3k    {} ns/op", ns/2000);
-    // 10k threads
-    let start = SystemTime::now();
-    fib_thread(10000);
-    let end = SystemTime::now();
-    let duration = end.duration_since(start)
-        .expect("Time went backwards");
-    let ns = duration.as_nanos();
-    println!("fib_10k    {} ns/op", ns/2000);
-    // 20k threads
-    let start = SystemTime::now();
-    fib_thread(20000);
-    let end = SystemTime::now();
-    let duration = end.duration_since(start)
-        .expect("Time went backwards");
-    let ns = duration.as_nanos();
-    println!("fib_20k    {} ns/op", ns/2000);
-    // 40k threads
-    let start = SystemTime::now();
-    fib_thread(40000);
-    let end = SystemTime::now();
-    let duration = end.duration_since(start)
-        .expect("Time went backwards");
-    let ns = duration.as_nanos();
-    println!("fib_40k    {} ns/op", ns/2000);
-    // fib sequential
-    // 2k threads
-    let start = SystemTime::now();
-    fib_seq(2000, 25000);
-    let end = SystemTime::now();
-    let duration = end.duration_since(start)
-        .expect("Time went backwards");
-    let ns = duration.as_nanos();
-    println!("fib_seq_2k    {} ns/op", ns/25000);
-    // 3k threads
-    let start = SystemTime::now();
-    fib_seq(3000, 14000);
-    let end = SystemTime::now();
-    let duration = end.duration_since(start)
-        .expect("Time went backwards");
-    let ns = duration.as_nanos();
-    println!("fib_seq_3k    {} ns/op", ns/14000);
-    // 10k threads
-    let start = SystemTime::now();
-    fib_seq(10000, 2500);
-    let end = SystemTime::now();
-    let duration = end.duration_since(start)
-        .expect("Time went backwards");
-    let ns = duration.as_nanos();
-    println!("fib_seq_10k    {} ns/op", ns/2500);
-    // 20k threads
-    let start = SystemTime::now();
-    fib_seq(20000, 900);
-    let end = SystemTime::now();
-    let duration = end.duration_since(start)
-        .expect("Time went backwards");
-    let ns = duration.as_nanos();
-    println!("fib_seq_20k    {} ns/op", ns/900);
-    // 40k threads
-    let start = SystemTime::now();
-    fib_seq(40000, 250);
-    let end = SystemTime::now();
-    let duration = end.duration_since(start)
-        .expect("Time went backwards");
-    let ns = duration.as_nanos();
-    println!("fib_seq_40k    {} ns/op", ns/250);
-}
-
-fn main(){
-    let start = SystemTime::now();
+fn main() {
+    let start = Instant::now();
     fib_thread_pool(2000);
-    let end = SystemTime::now();
-    let duration = end.duration_since(start)
-        .expect("Time went backwards");
+    let end = Instant::now();
+    let duration = end.duration_since(start);
     let ns = duration.as_nanos();
-    println!("fib_2k    {} ns/op", ns/2000);
-    // 3k threads
-    let start = SystemTime::now();
-    fib_thread_pool(3000);
-    let end = SystemTime::now();
-    let duration = end.duration_since(start)
-        .expect("Time went backwards");
-    let ns = duration.as_nanos();
-    println!("fib_3k    {} ns/op", ns/2000);
-    // 10k threads
-    let start = SystemTime::now();
-    fib_thread_pool(10000);
-    let end = SystemTime::now();
-    let duration = end.duration_since(start)
-        .expect("Time went backwards");
-    let ns = duration.as_nanos();
-    println!("fib_10k    {} ns/op", ns/2000);
-    // 20k threads
-    let start = SystemTime::now();
-    fib_thread_pool(20000);
-    let end = SystemTime::now();
-    let duration = end.duration_since(start)
-        .expect("Time went backwards");
-    let ns = duration.as_nanos();
-    println!("fib_20k    {} ns/op", ns/2000);
-    // 40k threads
-    let start = SystemTime::now();
-    fib_thread_pool(40000);
-    let end = SystemTime::now();
-    let duration = end.duration_since(start)
-        .expect("Time went backwards");
-    let ns = duration.as_nanos();
-    println!("fib_40k    {} ns/op", ns/2000);
-}
+    println!("fib_2k    {} ns/op", ns / 2000);
 
-fn fib_thread(n: usize) {
-    let (tx, rx) = mpsc::channel();
-    for _ in 0..2000 {
-        let tx = tx.clone();
-        thread::spawn(move || {
-            fib(n);
-            tx.send(());
-        });
-    }
-    for _ in 0..2000 {
-        rx.recv().ok();
-    }
+    let start = Instant::now();
+    fib_thread_pool(3000);
+    let end = Instant::now();
+    let duration = end.duration_since(start);
+    let ns = duration.as_nanos();
+    println!("fib_3k    {} ns/op", ns / 2000);
+
+    let start = Instant::now();
+    fib_thread_pool(10000);
+    let end = Instant::now();
+    let duration = end.duration_since(start);
+    let ns = duration.as_nanos();
+    println!("fib_10k    {} ns/op", ns / 2000);
+
+    let start = Instant::now();
+    fib_thread_pool(20000);
+    let end = Instant::now();
+    let duration = end.duration_since(start);
+    let ns = duration.as_nanos();
+    println!("fib_20k    {} ns/op", ns / 2000);
+
+    let start = Instant::now();
+    fib_thread_pool(40000);
+    let end = Instant::now();
+    let duration = end.duration_since(start);
+    let ns = duration.as_nanos();
+    println!("fib_40k    {} ns/op", ns / 2000);
 }
 
 fn fib_thread_pool(n: usize) {
-    let n_workers = 120;
-    let pool = ThreadPool::new(n_workers);
-    let (tx, rx) = mpsc::channel();
-    for _ in 0..2000 {
-        let tx = tx.clone();
-        pool.execute(move|| {
-            fib(n);
-            tx.send(1).expect("channel will be there waiting for the pool");
-        });
-    }
-    for _ in 0..2000 {
-        rx.recv().ok();
-    }
+    (0..2000)
+        .into_par_iter()
+        .map(|_| fib(n))
+        .collect::<Vec<_>>();
 }
-
-fn fib_seq(n: usize, size: usize) {
-    for _ in 0..size {
-        fib(n);
-    }
-}
-
-// #[bench]
-// fn bench_fib_3k(b: &mut Bencher) {
-//     b.iter(|| {
-//         let (tx, rx) = mpsc::channel();
-//         for _ in 0..2000 {
-//             let tx = tx.clone();
-//             thread::spawn(move || {
-//                 fib(3000);
-//                 tx.send(());
-//             });
-//         }
-//         for _ in 0..2000 {
-//             rx.recv();	
-//         }
-//     });
-// }
-
-// #[bench]
-// fn bench_fib_10k(b: &mut Bencher) {
-//     b.iter(|| {
-//         let (tx, rx) = mpsc::channel();
-//         for _ in 0..2000 {
-//             let tx = tx.clone();
-//             thread::spawn(move || {
-//                 fib(10000);
-//                 tx.send(());
-//             });
-//         }
-//         for _ in 0..2000 {
-//             rx.recv();	
-//         }
-//     });
-// }
-
-// #[bench]
-// fn bench_fib_20k(b: &mut Bencher) {
-//      b.iter(|| {fib_thread(20000)});
-// }
-
-// #[bench]
-// fn bench_fib_40k(b: &mut Bencher) {
-//      b.iter(|| {fib_thread(40000)});
-// }


### PR DESCRIPTION
I replaced BigInt with `u128` and `threadpool` with `rayon` and went from (on my machine) 

- fib_2k    20753 ns/op
- fib_3k    34711 ns/op
- fib_10k    239269 ns/op
- fib_20k    865958 ns/op
- fib_40k    3299590 ns/op

to 

- fib_2k    347 ns/op
- fib_3k    377 ns/op
- fib_10k    1190 ns/op
- fib_20k    2791 ns/op

also make sure to run with --release